### PR TITLE
udpated service worker logic to reduce perf effect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>JS TS Playground</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
@@ -38,20 +38,15 @@
             const swPath = `${scope}service-worker.js`.replace('//', '/');
             
             // Unregister any existing service workers first
-            const registrations = await navigator.serviceWorker.getRegistrations();
-            for(let registration of registrations) {
-              await registration.unregister();
-            }
+            // const registrations = await navigator.serviceWorker.getRegistrations();
+            // for(let registration of registrations) {
+            //   await registration.unregister();
+            // }
             
             // Register the new service worker
             const registration = await navigator.serviceWorker.register(swPath, {
               scope: scope
             });
-
-            console.dir({
-              message: `ServiceWorker registration successful with scope: ${registration.scope}`,
-              type: 'log'
-            })
           } catch (error) {
             console.dir({
               message: `ServiceWorker registration failed: ${error?.message}`,


### PR DESCRIPTION
## Description 

After Release of Service Worker Integration PR -> #9 
we saw a drop in performance for Webvitals, with this change we re-covered the loss we had in web performance.
To fix that, we made the following optimisations to recover the performance score loss, while maitainig the caching.
- removed the logic to Unregister any existing service workers first
- removed the console.dir statement for logging info, only kept for error logs.
- Reduced the `PRECACHE_URLS` urls
- Load PRECACHE_URLS and CDN_CHUNKS in paralle.
- Defered the call to `cacheWithTimestamp(event.request, responseToCache)`
- Defer cache cleanup related to keys which are not matching with our current cache key.

## Screenshots
*Perf Before* - 
<img width="643" alt="Screenshot 2025-02-16 at 2 55 03 PM" src="https://github.com/user-attachments/assets/32fa4082-a351-47a8-94cd-b7f8cb9f8da1" />

*Perf After* - 
<img width="644" alt="Screenshot 2025-02-16 at 3 07 22 PM" src="https://github.com/user-attachments/assets/5899770c-d7b6-4852-8f2a-64431c0ecf2e" />


## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules 