### PR TITLE
Feature/session manager

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,9 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 3. ...
 
 ## Checklist:
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] Any dependent changes have been merged and published in downstream modules 
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my own code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] I have made corresponding changes to the documentation
+- [x] My changes generate no new warnings
+- [x] Any dependent changes have been merged and published in downstream modules 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run pre-push

--- a/craco.config.js
+++ b/craco.config.js
@@ -8,7 +8,8 @@ module.exports = {
       '@constants': path.resolve(__dirname, 'src/constants'),
       '@styles': path.resolve(__dirname, 'src/styles'),
       '@utils': path.resolve(__dirname, 'src/utils'),
-      '@hooks': path.resolve(__dirname, 'src/hooks')
+      '@hooks': path.resolve(__dirname, 'src/hooks'),
+      '@contexts': path.resolve(__dirname, 'src/contexts')
     },
   },
   eslint: {
@@ -32,4 +33,4 @@ module.exports = {
       return middlewares;
     }
   }
-}; 
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "pre-push": "npm run build"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "@craco/craco": "7.1.0",
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
+    "@typescript-eslint/eslint-plugin": "5.5.0",
+    "@typescript-eslint/parser": "5.5.0",
+    "eslint": "8.0.0",
     "gh-pages": "6.3.0",
     "husky": "8.0.0",
     "lint-staged": "15.0.0",
@@ -23,21 +26,28 @@
     "build": "npm run type-check && craco build",
     "type-check": "tsc --noEmit",
     "type-check:watch": "tsc --noEmit --watch",
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["tsc --noEmit"]
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix"
+    ]
   },
   "eslintConfig": {
     "extends": [
-      "react-app"
+      "react-app",
+      "plugin:@typescript-eslint/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint"],
     "rules": {
       "no-eval": "off",
-      "no-new-func": "off"
+      "no-new-func": "off",
+      "@typescript-eslint/no-var-requires": "off"
     }
   },
   "browserslist": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,15 @@
-import { useState, useEffect } from 'react';
 import { Tab } from '@components/common/Tab';
 import { JavaScriptEditor } from '@components/JavaScriptEditor';
 import { TypeScriptEditor } from '@components/TypeScriptEditor';
-import { APP_CONSTANTS, LANGUAGES, Language } from '@constants/app';
-import { STORAGE_KEYS } from '@constants/storage';
+import { SessionManager } from '@components/SessionManager';
+import { APP_CONSTANTS, LANGUAGES } from '@constants/app';
+import { useSession } from '@contexts/SessionContext';
 import '@styles/app.css';
 
-const DEFAULT_LANGUAGE: Language = LANGUAGES.JAVASCRIPT;
-
 export const App = () => {
-  const [language, setLanguage] = useState<Language>(() => {
-    return (localStorage.getItem(STORAGE_KEYS.SELECTED_LANGUAGE) as Language) || DEFAULT_LANGUAGE;
-  });
+  const { activeSession, updateLanguage } = useSession();
 
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEYS.SELECTED_LANGUAGE, language);
-  }, [language]);
+  const currentLanguage = activeSession?.language || LANGUAGES.JAVASCRIPT;
 
   return (
     <div className="container">
@@ -32,20 +26,21 @@ export const App = () => {
         >
           GitHub
         </a>
-      </header>
-      <div className="tabs">
-        <Tab 
-          label="JavaScript"
-          isActive={language === LANGUAGES.JAVASCRIPT}
-          onClick={() => setLanguage(LANGUAGES.JAVASCRIPT)}
-        />
-        <Tab 
-          label="TypeScript"
-          isActive={language === LANGUAGES.TYPESCRIPT}
-          onClick={() => setLanguage(LANGUAGES.TYPESCRIPT)}
-        />
-      </div>
-      {language === LANGUAGES.JAVASCRIPT ? <JavaScriptEditor /> : <TypeScriptEditor />}
+    </header>
+    <SessionManager />
+    <div className="tabs">
+      <Tab 
+        label="JavaScript"
+        isActive={currentLanguage === LANGUAGES.JAVASCRIPT}
+        onClick={() => updateLanguage(LANGUAGES.JAVASCRIPT)}
+      />
+      <Tab 
+        label="TypeScript"
+        isActive={currentLanguage === LANGUAGES.TYPESCRIPT}
+        onClick={() => updateLanguage(LANGUAGES.TYPESCRIPT)}
+      />
+    </div>
+      {currentLanguage === LANGUAGES.JAVASCRIPT ? <JavaScriptEditor /> : <TypeScriptEditor />}
     </div>
   );
 }

--- a/src/components/EditorBase.tsx
+++ b/src/components/EditorBase.tsx
@@ -11,9 +11,10 @@ import { overrideConsoleMethods } from '@utils/console/override';
 import { SHORTCUTS } from '@constants/shortcuts';
 import { useWindowResize } from '@hooks/useWindowResize';
 import { useSession } from '@contexts/SessionContext';
+import { ConsoleMessage } from 'types/console';
 
 export const EditorBase = ({ language, handleCodeExecution }: EditorBaseProps) => {
-  const [output, setOutput] = useState<any[]>([]);
+  const [output, setOutput] = useState<ConsoleMessage[]>([]);
   const { editorKey } = useWindowResize();
   const [autoRun, setAutoRun] = useState<boolean>(() => {
     return localStorage.getItem(STORAGE_KEYS.AUTO_RUN) !== 'false';
@@ -44,7 +45,7 @@ export const EditorBase = ({ language, handleCodeExecution }: EditorBaseProps) =
   }, [autoRun]);
 
   const handleEditorMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: Monaco) => {
-    (window as any).editor = editor;
+    window.editor = editor;
 
     // Add command for running code
     editor.addCommand(
@@ -60,7 +61,7 @@ export const EditorBase = ({ language, handleCodeExecution }: EditorBaseProps) =
     <div className="editor-output-container">
       <div className="editor-container">
         <EditorControls
-          onRun={() => handleRunCode((window as any).editor)}
+          onRun={() => handleRunCode(window.editor)}
           autoRun={autoRun}
           setAutoRun={setAutoRun}
         />
@@ -76,7 +77,7 @@ export const EditorBase = ({ language, handleCodeExecution }: EditorBaseProps) =
             automaticLayout: true,
           }}
           onChange={(value) => {
-            debouncedSetEditorContent(value || '', (window as any).editor);
+            debouncedSetEditorContent(value || '', window.editor);
           }}
           onMount={handleEditorMount}
         />

--- a/src/components/JavaScriptEditor.tsx
+++ b/src/components/JavaScriptEditor.tsx
@@ -4,7 +4,7 @@ import { EditorBaseProps } from 'types/editor';
 import { LANGUAGES } from '@constants/app';
 import { __handleError } from '@utils/errorHandlerOverrides';
 
-export const JavaScriptEditor: React.FC = () => {
+export const JavaScriptEditor = () => {
   const handleCodeExecution: EditorBaseProps['handleCodeExecution'] = async (code) => {
     try {
       eval(code);

--- a/src/components/SessionManager.tsx
+++ b/src/components/SessionManager.tsx
@@ -1,0 +1,49 @@
+import { MAX_SESSIONS } from '../hooks/useCodeSessions';
+import { useSession } from '@contexts/SessionContext';
+
+export function SessionManager() {
+  const {
+    sessions,
+    activeSessionId,
+    setActiveSessionId,
+    createSession,
+    deleteSession
+  } = useSession();
+
+  const handleNewSession = () => {
+    try {
+      createSession();
+    } catch (error) {
+      alert('Maximum session limit (10) reached!');
+    }
+  };
+
+  return (
+    <div className="session-manager">
+      <div className="session-tabs">
+        {sessions.map(session => (
+          <div
+            key={session.id}
+            className={`session-tab ${session.id === activeSessionId ? 'active' : ''}`}
+            onClick={() => setActiveSessionId(session.id)}
+          >
+            <span>{session.title}</span>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                deleteSession(session.id);
+              }}
+            >
+              x
+            </button>
+          </div>
+        ))}
+        {sessions.length < MAX_SESSIONS && (
+          <button className="new-session-btn" onClick={handleNewSession}>
+            +
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionManager.tsx
+++ b/src/components/SessionManager.tsx
@@ -1,5 +1,7 @@
 import { MAX_SESSIONS } from '../hooks/useCodeSessions';
 import { useSession } from '@contexts/SessionContext';
+import { useState, useRef, useEffect } from 'react';
+import { MAX_SESSION_TITLE_LENGTH } from '@constants/app';
 
 export function SessionManager() {
   const {
@@ -7,14 +9,53 @@ export function SessionManager() {
     activeSessionId,
     setActiveSessionId,
     createSession,
-    deleteSession
+    deleteSession,
+    updateSession
   } = useSession();
+
+  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editingSessionId && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editingSessionId]);
 
   const handleNewSession = () => {
     try {
       createSession();
     } catch (error) {
       alert('Maximum session limit (10) reached!');
+    }
+  };
+
+  const startEditing = (session: { id: string, title: string }, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingSessionId(session.id);
+    setEditValue(session.title);
+  };
+
+  const handleSave = (id: string) => {
+    const trimmedValue = editValue.trim();
+    if (!trimmedValue) {
+      // If empty, revert to the original title
+      const originalTitle = sessions.find(s => s.id === id)?.title || '';
+      setEditValue(originalTitle);
+      setEditingSessionId(null);
+      return;
+    }
+    updateSession(id, { title: trimmedValue.slice(0, MAX_SESSION_TITLE_LENGTH) });
+    setEditingSessionId(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent, id: string) => {
+    if (e.key === 'Enter') {
+      handleSave(id);
+    } else if (e.key === 'Escape') {
+      setEditingSessionId(null);
     }
   };
 
@@ -26,20 +67,41 @@ export function SessionManager() {
             key={session.id}
             className={`session-tab ${session.id === activeSessionId ? 'active' : ''}`}
             onClick={() => setActiveSessionId(session.id)}
+            title="Double click to edit session title"
           >
-            <span>{session.title}</span>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                deleteSession(session.id);
-              }}
-            >
-              x
-            </button>
+            {editingSessionId === session.id ? (
+              <input
+                ref={inputRef}
+                type="text"
+                value={editValue}
+                maxLength={MAX_SESSION_TITLE_LENGTH}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={() => handleSave(session.id)}
+                onKeyDown={(e) => handleKeyDown(e, session.id)}
+                onClick={(e) => e.stopPropagation()}
+                className="session-title-input"
+                name={`session-title-${session.id}`}
+                placeholder="(required)"
+                required
+              />
+            ) : (
+              <div onDoubleClick={(e) => startEditing(session, e)}>{session.title}</div>
+            )}
+            {sessions.length > 1 && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteSession(session.id);
+                }}
+                title="Delete session"
+              >
+                x
+              </button>
+            )}
           </div>
         ))}
         {sessions.length < MAX_SESSIONS && (
-          <button className="new-session-btn" onClick={handleNewSession}>
+          <button className="new-session-btn" onClick={handleNewSession} title="Create a new session">
             +
           </button>
         )}

--- a/src/components/TypeScriptEditor.tsx
+++ b/src/components/TypeScriptEditor.tsx
@@ -6,7 +6,7 @@ import { __handleError } from '@utils/errorHandlerOverrides';
 import { loadTypeScriptCompiler } from '@utils/typescript-loader';
 import { checkEditorErrors } from '@utils/monaco';
 
-export const TypeScriptEditor: React.FC = () => {
+export const TypeScriptEditor = () => {
   loadTypeScriptCompiler();
 
   const handleCodeExecution: EditorBaseProps['handleCodeExecution'] = async (code) => {

--- a/src/components/common/ConsoleArrayItem.tsx
+++ b/src/components/common/ConsoleArrayItem.tsx
@@ -7,7 +7,7 @@ import { ConsolePrimitive } from '@common/ConsolePrimitive';
 import { formatArrayPreview } from '@utils/console/formatters';
 
 interface ConsoleArrayItemProps {
-  val: any;
+  val: unknown;
   idx: number;
   type: ConsoleOutputProps['type'];
 }
@@ -55,4 +55,4 @@ export const ConsoleArrayItem: React.FC<ConsoleArrayItemProps> = ({ val, idx, ty
       <ConsolePrimitive value={val} type={type} />
     </React.Fragment>
   );
-}; 
+};

--- a/src/components/common/ConsolePromise.tsx
+++ b/src/components/common/ConsolePromise.tsx
@@ -7,7 +7,7 @@ import {
 } from '@constants/promise';
 
 interface ConsolePromiseProps {
-  value: Promise<any>;
+  value: Promise<unknown>;
   type: ConsoleOutputProps['type'];
 }
 
@@ -18,7 +18,7 @@ const formatError = (error: unknown): string =>
 
 export const ConsolePromise: React.FC<ConsolePromiseProps> = ({ value, type }) => {
   const [promiseState, setPromiseState] = useState<PromiseState>(PROMISE_STATES.PENDING);
-  const [promiseResult, setPromiseResult] = useState<any>(undefined);
+  const [promiseResult, setPromiseResult] = useState<unknown>(undefined);
 
   useEffect(() => {
     let mounted = true;

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -19,3 +19,5 @@ export const CDN_URLS = {
 } as const;
 
 export type CDNUrl = typeof CDN_URLS[keyof typeof CDN_URLS];
+
+export const MAX_SESSION_TITLE_LENGTH = 20;

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useCallback, useMemo } from 'react';
+import { useCodeSessions } from '@hooks/useCodeSessions';
+import { SessionContextType } from 'types/session';
+import { Language } from '@constants/app';
+
+const SessionContext = createContext<SessionContextType | null>(null);
+
+export const useSession = () => {
+  const context = useContext(SessionContext);
+  if (!context) {
+    throw new Error('useSession must be used within a SessionProvider');
+  }
+  return context;
+};
+
+export const SessionProvider = ({ children }: React.PropsWithChildren) => {
+  const { 
+    sessions,
+    activeSessionId,
+    setActiveSessionId,
+    createSession,
+    deleteSession,
+    updateSession,
+    getActiveSession
+  } = useCodeSessions();
+
+  const activeSession = getActiveSession();
+
+  const updateCode = useCallback((code: string) => {
+    if (activeSession) {
+      updateSession(activeSession.id, { code });
+    }
+  }, [activeSession, updateSession]);
+
+  const updateLanguage = useCallback((language: Language) => {
+    if (activeSession) {
+      updateSession(activeSession.id, { language });
+    }
+  }, [activeSession, updateSession]);
+
+  const contextValue = useMemo(() => ({
+    sessions,
+    activeSession,
+    activeSessionId,
+    setActiveSessionId,
+    createSession,
+    deleteSession,
+    updateSession,
+    updateCode,
+    updateLanguage
+  }), [sessions, activeSession, activeSessionId, setActiveSessionId, createSession, deleteSession, updateSession, updateCode, updateLanguage]);
+
+  return (
+    <SessionContext.Provider value={contextValue}>
+      {children}
+    </SessionContext.Provider>
+  );
+};

--- a/src/hooks/useCodeSessions.ts
+++ b/src/hooks/useCodeSessions.ts
@@ -1,0 +1,91 @@
+import { APP_CONSTANTS, LANGUAGES } from '@constants/app';
+import { useState, useEffect } from 'react';
+import { CodeSession } from 'types/session';
+
+export const MAX_SESSIONS = 10;
+const STORAGE_KEY = 'code-sessions';
+
+export const useCodeSessions = () => {
+  const [sessions, setSessions] = useState<CodeSession[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+
+  // Load sessions from localStorage on mount
+  useEffect(() => {
+    try {
+      const storedSessions = localStorage.getItem(STORAGE_KEY);
+      if (!storedSessions) {
+        throw new Error('No sessions found');
+      }
+
+      const parsedSessions = JSON.parse(storedSessions);
+      if (!Array.isArray(parsedSessions)) {
+        throw new Error('Invalid sessions data');
+      }
+
+      if (parsedSessions.length === 0) {
+        throw new Error('No sessions found');
+      }
+
+      setSessions(parsedSessions);
+      setActiveSessionId(parsedSessions[0].id);
+    } catch (error) {
+      createSession();
+    }
+  }, []);
+
+  // Save sessions to localStorage whenever they change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+  }, [sessions]);
+
+  const createSession = () => {
+    if (sessions.length >= MAX_SESSIONS) {
+      throw new Error('Maximum session limit reached');
+    }
+
+    const newSession: CodeSession = {
+      id: Date.now().toString(),
+      title: `Session ${sessions.length + 1}`,
+      code: APP_CONSTANTS.DEFAULT_CODE,
+      language: LANGUAGES.JAVASCRIPT,
+      createdAt: Date.now(),
+      lastModified: Date.now(),
+    };
+
+    setSessions(prev => [newSession, ...prev]);
+    setActiveSessionId(newSession.id);
+    return newSession;
+  };
+
+  const updateSession = (id: string, updates: Partial<CodeSession>) => {
+    setSessions(prev => prev.map(session => 
+      session.id === id 
+        ? { ...session, ...updates, lastModified: Date.now() }
+        : session
+    ));
+  };
+
+  const deleteSession = (id: string) => {
+    setSessions(prev => prev.filter(session => session.id !== id));
+    if (activeSessionId === id) {
+      const remainingSessions = sessions.filter(session => session.id !== id);
+      setActiveSessionId(remainingSessions[0]?.id || null);
+    }
+  };
+
+  const getActiveSession = () => {
+    return sessions.find(session => session.id === activeSessionId) || null;
+  };
+
+  console.dir(`activeSession: ${getActiveSession()}, activeSessionId: ${activeSessionId}`)
+
+  return {
+    sessions,
+    activeSessionId,
+    setActiveSessionId,
+    createSession,
+    updateSession,
+    deleteSession,
+    getActiveSession,
+  };
+};

--- a/src/hooks/useCodeSessions.ts
+++ b/src/hooks/useCodeSessions.ts
@@ -77,8 +77,6 @@ export const useCodeSessions = () => {
     return sessions.find(session => session.id === activeSessionId) || null;
   };
 
-  console.dir(`activeSession: ${getActiveSession()}, activeSessionId: ${activeSessionId}`)
-
   return {
     sessions,
     activeSessionId,

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useEffect } from 'react';
 
 export function useDebounce<T extends (...args: any[]) => void>(
   callback: T,
-  delay: number = 500
+  delay = 500
 ): T {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import { App } from './App';
 import { errorHandlerOverrides } from '@utils/errorHandlerOverrides';
-
+import { SessionProvider } from '@contexts/SessionContext';
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 
 errorHandlerOverrides();
-root.render(<App />);
+root.render(
+  <SessionProvider>
+    <App />
+  </SessionProvider>
+);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3,3 +3,4 @@
 @import '@styles/editor.css';
 @import '@styles/console.css';
 @import '@styles/components/index.css';
+@import '@styles/sessionManager.css';

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -35,10 +35,10 @@
   border: none;
   border-radius: var(--border-radius);
   cursor: pointer;
-  background-color: #f0f0f0;
+  background: var(--tab-bg);
 }
 
 .tab-btn.active {
   background-color: var(--primary-color);
   color: white;
-} 
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,5 +1,5 @@
 .container {
-  padding: 12px;
+  padding: 8px;
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/styles/sessionManager.css
+++ b/src/styles/sessionManager.css
@@ -1,0 +1,86 @@
+.session-manager {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.session-tabs {
+  display: flex;
+  gap: 4px;
+  height: 36px;
+  position: relative;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.session-tab {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px;
+  width: 140px;
+  background: none;
+  border: none;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  position: relative;
+}
+
+.session-tab::after {
+  content: '';
+  position: absolute;
+  right: -3px;
+  width: 2px;
+  height: 70%;
+  background: var(--tab-active-bg);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.session-tab:not(.active, :hover, :last-of-type, :has(+ .active, +:hover))::after {
+  opacity: 1;
+}
+
+.session-tab:hover {
+  background: var(--tab-hover-bg);
+}
+
+.session-tab.active {
+  background: var(--tab-active-bg)
+}
+
+.session-tab button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: opacity 0.2s, background-color 0.2s;
+}
+
+.session-tab button:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.new-session-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  padding: 4px 8px;
+  align-self: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+  margin-left: 4px;
+}
+
+.new-session-btn:hover {
+  background: var(--tab-hover-bg);
+}

--- a/src/styles/sessionManager.css
+++ b/src/styles/sessionManager.css
@@ -16,13 +16,21 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 8px;
-  width: 140px;
+  width: 156px;
   background: none;
   border: none;
   border-radius: 8px 8px 0 0;
   cursor: pointer;
   transition: background-color 0.2s;
   position: relative;
+}
+
+.session-tab div {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
 }
 
 .session-tab::after {
@@ -64,6 +72,22 @@
 .session-tab button:hover {
   opacity: 1;
   background: rgba(0, 0, 0, 0.1);
+}
+
+.session-title-input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--primary-color);
+  border-radius: var(--border-radius);
+  padding: 6px;
+  outline: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.session-title-input[value=""] {
+  border-color: var(--console-error);
 }
 
 .new-session-btn {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -9,6 +9,11 @@
   --border-dark: #444;
   --border-darker: #333;
   
+  /* Tab Colors */
+  --tab-bg: #f0f0f0;
+  --tab-active-bg: #ccc;
+  --tab-hover-bg: #f0f0f0;
+  
   /* Console Colors */
   --console-warn: #ffbb33;
   --console-error: #ff4444;
@@ -34,4 +39,4 @@
   
   /* Border Radius */
   --border-radius: 4px;
-} 
+}

--- a/src/types/console.d.ts
+++ b/src/types/console.d.ts
@@ -7,7 +7,7 @@ export type ConsoleMethodTypeExcludingTable = Exclude<ConsoleMethodType, typeof 
 
 export interface ConsoleMessage {
   type: ConsoleMethodType;
-  value: any[];
+  value: unknown[];
 }
 
 export interface TimeData {
@@ -15,13 +15,13 @@ export interface TimeData {
 }
 
 export interface ConsoleOutputProps {
-  value: any;
+  value: unknown;
   depth?: number;
   type?: ConsoleMethodType;
-  seen?: WeakMap<any, string>;
+  seen?: WeakMap<unknown, string>;
 }
 
 export interface ConsoleOutputContainerProps {
   output: ConsoleMessage[];
   setOutput: SetOutputFunction;
-} 
+}

--- a/src/types/monaco.d.ts
+++ b/src/types/monaco.d.ts
@@ -10,13 +10,13 @@ declare namespace Monaco {
 
   interface Editor {
     getModel: () => {
-      uri: any;
+      uri: monaco.Uri;
     };
     getValue: () => string;
   }
 
   interface MonacoEditor {
-    getModelMarkers: (filter: { resource: any }) => IMarker[];
+    getModelMarkers: (filter: { resource: monaco.Uri }) => IMarker[];
     MarkerSeverity: {
       Error: number;
       Warning: number;
@@ -31,7 +31,7 @@ declare global {
     monaco: {
       editor: Monaco.MonacoEditor;
     };
-    editor: Monaco.Editor;
+    editor: monacoEditor.editor.IStandaloneCodeEditor;
   }
 }
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,0 +1,22 @@
+import { Language } from "@constants/app";
+
+export interface CodeSession {
+  id: string;
+  title: string;
+  code: string;
+  language: Language;
+  createdAt: number;
+  lastModified: number;
+}
+
+export interface SessionContextType {
+  sessions: CodeSession[];
+  activeSession: CodeSession | null;
+  activeSessionId: string | null;
+  setActiveSessionId: (id: CodeSession['id']) => void;
+  createSession: () => void;
+  deleteSession: (id: CodeSession['id']) => void;
+  updateSession: (id: CodeSession['id'], updates: Partial<CodeSession>) => void;
+  updateCode: (code: string) => void;
+  updateLanguage: (language: Language) => void;
+}

--- a/src/utils/console/formatters.ts
+++ b/src/utils/console/formatters.ts
@@ -1,4 +1,4 @@
-export const formatConsoleValue = (value: any): string => {
+export const formatConsoleValue = (value: unknown): string => {
   if (typeof value === 'object' && value !== null) {
     return JSON.stringify(value, null, 2);
   }
@@ -9,7 +9,7 @@ export const formatTimerDuration = (duration: number): string => {
   return `${duration.toFixed(2)}ms`;
 };
 
-export const formatArrayPreview = (arr: any[], depth: number = 0): string => {
+export const formatArrayPreview = (arr: unknown[], depth = 0): string => {
   return arr.map(item => {
     if (Array.isArray(item)) {
       if (depth >= 1) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,10 @@
       "@constants/*": ["constants/*"],
       "@styles/*": ["styles/*"],
       "@utils/*": ["utils/*"],
-      "@hooks/*": ["hooks/*"]
+      "@hooks/*": ["hooks/*"],
+      "@contexts/*": ["contexts/*"]
     }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build", "dist", "scripts", "acceptance-tests", "webpack", "jest"]
-} 
+}


### PR DESCRIPTION
## Description
### Session Manager Implementation

#### Changes
- Added Session Manager component for managing multiple code sessions
- Implemented session tabs with Chrome-like UI
- Added session context for state management
- Added pre-push and pre-commit hooks for better code quality
- Modified PR template for standardized pull requests

#### Session Manager Features
- Multiple code session support
- Tab-based navigation between sessions
- Chrome-like tab UI with:
  - Active tab highlighting
  - Hover states
  - Divider between tabs
  - Close button for each tab
  - New session button
- Session state persistence

#### Development Workflow Improvements
1. **Pre-commit Hook**:
   - ESLint checks with auto-fix
   - TypeScript type checking
   - Enforced code style consistency

2. **Pre-push Hook**:
   - Full build verification
   - Type checking across the project
   - Prevents pushing broken builds

3. **Code Quality**:
   - Added strict TypeScript types for Monaco editor
   - Improved type safety by removing `any` types
   - ESLint configuration updates

## Screenshots
<img width="1470" alt="Screenshot 2025-03-02 at 12 24 19 AM" src="https://github.com/user-attachments/assets/cb6e49d5-86d4-4fe2-bb67-32929ecbcd7b" />


## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] Multiple sessions creation and switching
- [x] Session state persistence
- [x] Tab UI interactions
- [x] Build process with new hooks
- [x] Type checking with stricter rules


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules 