### PR TITLE
hotfix: handle get method and query params in makeApiRequest

### DIFF
--- a/src/utils/centralServerApis.ts
+++ b/src/utils/centralServerApis.ts
@@ -1,24 +1,28 @@
 import { APP_CONSTANTS } from '@constants/app';
 import type { CodeSessionResponse } from 'types/session';
 
-const makeApiRequest = async (
-  method: string,
-  body: Record<string, unknown>
-) => {
-  const response = await fetch(APP_CONSTANTS.CODE_SESSION_API_URL, {
+const makeApiRequest = async (method: string, body: Record<string, unknown>) => {
+  const url = new URL(APP_CONSTANTS.CODE_SESSION_API_URL);
+
+  if (method === 'GET') {
+    for (const key in body) {
+      url.searchParams.append(key, String(body[key]));
+    }
+  }
+
+  const response = await fetch(url, {
     method,
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(body),
+    body: method === 'GET' ? undefined : JSON.stringify(body),
   });
 
   return await response.json();
 };
 
 const handleApiError = (error: unknown) => {
-  const errorMessage =
-    error instanceof Error ? error.message : 'Something went wrong! Try again.';
+  const errorMessage = error instanceof Error ? error.message : 'Something went wrong! Try again.';
 
   return {
     error: errorMessage,
@@ -64,11 +68,7 @@ const createCodeSession = async (code: string, language: string) => {
   }
 };
 
-const updateCodeSession = async (
-  sessionId: string,
-  code: string,
-  language: string
-) => {
+const updateCodeSession = async (sessionId: string, code: string, language: string) => {
   try {
     const { data }: CodeSessionResponse = await makeApiRequest('PATCH', {
       id: sessionId,


### PR DESCRIPTION
## Description
Error - Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body.
Fix - Handle GET method and query params explicitly in makeApiRequest method.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules 