### PR TITLE
feature: track and udpate and get last active session

### DIFF
--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,5 +1,4 @@
 export const STORAGE_KEYS = {
-  SELECTED_LANGUAGE: 'selectedLanguage',
   AUTO_RUN: 'autoRun',
-  EDITOR_CONTENT: (language: string) => `${language}EditorContent`,
-} as const; 
+  LAST_ACTIVE_SESSION: 'lastActiveSession',
+} as const;

--- a/src/hooks/useCodeSessions.ts
+++ b/src/hooks/useCodeSessions.ts
@@ -10,11 +10,13 @@ import {
   saveSessionMetadata,
   getSessionsFromLocalDB,
   getUpdatedSessionsWithLocalDBCodes,
+  setLastActiveSession,
+  getLastActiveSession,
 } from '@utils/codeSessions';
 
 export const useCodeSessions = () => {
   const [sessions, setSessions] = useState<CodeSession[]>([]);
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(getLastActiveSession());
   const hasLoadedCodes = useRef(false);
   const paramSessionId = getSearchParams('id');
 
@@ -125,6 +127,11 @@ export const useCodeSessions = () => {
   useEffect(() => {
     saveSessionMetadata(sessions);
   }, [sessions]);
+
+  // Save last active session when active session changes
+  useEffect(() => {
+    activeSessionId && setLastActiveSession(activeSessionId);
+  }, [activeSessionId]);
 
   const createSession = async () => {
     if (sessions.length >= APP_CONSTANTS.MAX_SESSIONS) {

--- a/src/hooks/useCodeSessions.ts
+++ b/src/hooks/useCodeSessions.ts
@@ -99,11 +99,13 @@ export const useCodeSessions = () => {
         ...m,
         code: APP_CONSTANTS.GETTING_CODE_MESSAGE,
       }));
-      const activeSessionId =
-        initialSessions.find(s => s.id === paramSessionId)?.id || initialSessions[0].id;
+      const newActiveSessionId =
+        initialSessions.find(s => s.id === paramSessionId)?.id ||
+        initialSessions.find(s => s.id === activeSessionId)?.id ||
+        initialSessions[0].id;
 
       setSessions(initialSessions);
-      setActiveSessionId(activeSessionId);
+      setActiveSessionId(newActiveSessionId);
     };
 
     initializeSessions();

--- a/src/utils/codeSessions.ts
+++ b/src/utils/codeSessions.ts
@@ -2,6 +2,7 @@ import { APP_CONSTANTS, LANGUAGES } from '@constants/app';
 import type { CodeSession, SessionMetadata } from 'types/session';
 import { getCode } from '@utils/indexedDB';
 import { PROMISE_STATES } from '@constants/promise';
+import { STORAGE_KEYS } from '@constants/storage';
 
 const STORAGE_KEY = 'code-sessions';
 
@@ -65,4 +66,18 @@ export const getUpdatedSessionsWithLocalDBCodes = (
     }
   });
   return updatedSessions;
+};
+
+export const getLastActiveSession = (): string | null => {
+  const lastActiveSession = localStorage.getItem(STORAGE_KEYS.LAST_ACTIVE_SESSION);
+
+  try {
+    return lastActiveSession ? JSON.parse(lastActiveSession) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const setLastActiveSession = (sessionId: string) => {
+  localStorage.setItem(STORAGE_KEYS.LAST_ACTIVE_SESSION, JSON.stringify(sessionId));
 };


### PR DESCRIPTION
## Description
track and udpate and get last active session
localStorageKey - `lastActiveSession`

closes: #19 

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules 